### PR TITLE
backuptool: Ensure dedicated partitions are not unused before mounting

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -142,7 +142,8 @@ BLK_PATH=$(dirname "$SYSDEV")
 mount_extra() {
   for partition in $@; do
     mnt_point="/$partition"
-    mountpoint "$mnt_point" >/dev/null 2>&1 && break
+    mountpoint "$mnt_point" >/dev/null 2>&1 && continue
+    [ -L "$SYSMOUNT/$partition" ] && continue
 
     blk_dev=$(find_block "$partition")
     if [ -e "$blk_dev" ]; then

--- a/prebuilt/common/bin/backuptool_ab.sh
+++ b/prebuilt/common/bin/backuptool_ab.sh
@@ -145,7 +145,8 @@ fi
 mount_extra() {
   for partition in $@; do
     mnt_point="/postinstall/$partition"
-    mountpoint "$mnt_point" >/dev/null 2>&1 && break
+    mountpoint "$mnt_point" >/dev/null 2>&1 && continue
+    [ -L "$mnt_point" ] && continue
 
     blk_dev=$(find_block "$partition")
     if [ -n "$blk_dev" ]; then


### PR DESCRIPTION
* Ignore the block devices in case their mount points are symlinks.
  This is common on devices where maintainers have chosen not to use
  real partitions because of their size being too small to be useful

Also `continue` instead of `break`. Oops.

Change-Id: I3e27abe510219066ecacd81d099220ac8e119f9f