### PR TITLE
Allow unified location provider as possible location provider (not as…

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -16,11 +16,30 @@
      limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Package name(s) containing location provider support.
+         These packages can contain services implementing location providers,
+         such as the Geocode Provider, Network Location Provider, and Fused
+         Location Provider.
+         The signatures of packages named below and installed in the system
+         image are "allowed" signatures.
+         The location framework checks ALL installed packages if they provide
+         an implementation of a specific location provider and compares the
+         signature of the package with the list of allowed signatures.
+
+         The location framework has support for installation of new or
+         updated location providers at run-time. However the new package must
+         have a signature that matches the signature of at least one package
+         on this list which is installed in the system image.
+
+         The chosen package for the specific location provider does not
+         depend on the order of this list. -->
     <string-array name="config_locationProviderPackageNames" translatable="false">
         <!-- The Google provider -->
         <item>com.google.android.gms</item>
         <!-- The standard AOSP fused location provider -->
         <item>com.android.location.fused</item>
+        <!-- The MicroG Unified location provider -->
+        <item>org.microg.nlp</item>
     </string-array>
 
     <bool name="config_cellBroadcastAppLinks">true</bool>


### PR DESCRIPTION
… used location provider)

As described in 204837/2#message-9ecc61fe611f195b13f5770e33904afccb01c2fa :
The "network location provider" which is finally used is selected in three steps:
- first the signatures of all packages, which are in this list AND which are installed in system, are collected (services/core/java/com/android/server/ServiceWatcher.java#L96)
- secondly the packages which implement the "network location provider service" are selected and their signatures are compared against the previous collected signatures (#L225)
- thirdly these packages are requested for their "serviceVersion" in metadate. The package which provides the highest version is used. If there are two packages with the same serviceVersion the first selected wins. (#L243)

There are no security implications because there has to be a proper signed package of "org.microg.nlp" in sytem first. (The check against the signature of this package allows for later updates of the package outside of system)

To quote Andreas Schneider from 204837:
"This doesn't have security implications as in order to use the location provider in needs to be installed as a system app. However this would allow it to be flashed to system like gapps."

On my opinion it's up to the user to decide if he want to use Gapps and Unified / MicroG. But in the first place this patch is needed to make it possible.

Change-Id: I4a046ead2cc46929d2c18cfe1561becb10a75bcd