### PR TITLE
lineage: Handle build type suffixes properly

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -73,8 +73,7 @@ function breakfast()
         # No arguments, so let's have the full menu
         lunch
     else
-        echo "z$target" | grep -q "-"
-        if [ $? -eq 0 ]; then
+        if [[ "$target" =~ -(user|userdebug|eng)$ ]]; then
             # A buildtype was specified, assume a full device name
             lunch $target
         else


### PR DESCRIPTION
This gets rid of grep error code when running breakfast.

Change-Id: I7a8eb86b6068ae1973a96a929129da9eaa84865c